### PR TITLE
Add path import back to middleware.js to fix broken production build

### DIFF
--- a/backend/server/middleware.js
+++ b/backend/server/middleware.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const express = require('express');
 const helmet = require('helmet');
 const { userHasToken } = require('../api/utils/authUtils');
@@ -9,11 +10,7 @@ module.exports = {
 
     // In production build, serve frontend build as static files
     if (process.env.NODE_ENV === 'production') {
-      server.use(
-        express.static(
-          path.resolve(__dirname, '../../frontend/lambda-in/build')
-        )
-      );
+      server.use(express.static(path.resolve(__dirname, '../../frontend/lambda-in/build')));
     }
   },
   auth(server) {


### PR DESCRIPTION
# Description

While syncing the deploy branch with the master branch, the path import from middleware.js was removed. This should fix the production build.

Fixes #
https://github.com/Lambda-School-Labs/CS10-Developer-Profiles/issues/46

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Deployed this branch to a test app on Heroku

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
